### PR TITLE
Feat: Select multiple profiles and launch them all in one click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flyzer",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flyzer",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flyzer",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.4",
   "scripts": {
     "dev": "next dev -p 1420",
     "build": "next build && next export -o dist",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "flyzer"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flyzer"
-version = "0.1.2"
+version = "0.1.4"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,7 +17,6 @@ fn main() {
                 list_profiles,
                 create_profile,
                 delete_profile,
-                open_all_profiles,
                 update_profile
             ]
         )
@@ -50,7 +49,7 @@ fn get_profile_path(app_handle: &tauri::AppHandle, profile_id: &String) -> PathB
 }
 
 #[tauri::command]
-fn open_window(profile_id: String, app_handle: tauri::AppHandle) {
+async fn open_window(profile_id: String, app_handle: tauri::AppHandle) {
     // Create data directory path
     let data_directory: PathBuf = get_profile_path(&app_handle, &profile_id);
 
@@ -80,13 +79,6 @@ fn open_window(profile_id: String, app_handle: tauri::AppHandle) {
 
     // Open window
     drop(window.show());
-}
-
-#[tauri::command]
-fn open_all_profiles(app_handle: tauri::AppHandle) {
-    for profile_id in list_profiles(app_handle.clone()) {
-        open_window(profile_id, app_handle.clone());
-    }
 }
 
 #[tauri::command]

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -28,14 +28,22 @@ import AddProfileButton from "../components/AddProfileButton";
 function App() {
   const [loading, setLoading] = useState<boolean>(true);
   const [profiles, setProfiles] = useState<string[]>([]);
-  const [selectedProfile, setSelectedProfile] = useState<string>("");
+  const [selectedProfiles, setSelectedProfiles] = useState<string[]>([]);
+
+  const toggleSelectedProfile = (profile) => {
+    if (selectedProfiles.includes(profile)) {
+      setSelectedProfiles([...selectedProfiles.filter(selectedProfile => selectedProfile !== profile)])
+    } else {
+      setSelectedProfiles([...selectedProfiles, profile])
+    }
+  }
 
   const getProfiles = useCallback(
     async () =>
       invoke("list_profiles").then((value: string[]) => {
         if (value) {
           setProfiles(value.sort((a, b) => a.localeCompare(b)));
-          setSelectedProfile(value[0]);
+          setSelectedProfiles([value[0]]);
           setLoading(false);
         }
       }),
@@ -92,7 +100,7 @@ function App() {
             <Box>
               <Grid container justifyContent="center" pb={2}>
                 <Button
-                  disabled={!selectedProfile}
+                  disabled={selectedProfiles.length === 0}
                   sx={{
                     fontSize: "xl",
                     color: "black",
@@ -105,7 +113,9 @@ function App() {
                     p: 3,
                   }}
                   onClick={async () =>
-                    invoke("open_window", { profileId: selectedProfile })
+                    selectedProfiles.forEach(profile => {
+                      invoke("open_window", { profileId: profile })
+                    })
                   }
                 >
                   Launch
@@ -118,7 +128,9 @@ function App() {
                   <MenuItem
                     variant="soft"
                     onClick={async () => {
-                      await invoke("open_all_profiles");
+                      profiles.forEach(profile => {
+                        invoke("open_window", { profileId: profile })
+                      })
                       handleClose();
                     }}
                   >
@@ -161,8 +173,8 @@ function App() {
                         {profiles?.length ? (
                           profiles.map((profile) => (
                             <ListItemButton
-                              onClick={() => setSelectedProfile(profile)}
-                              selected={selectedProfile === profile}
+                              onClick={() => toggleSelectedProfile(profile)}
+                              selected={selectedProfiles.includes(profile)}
                             >
                               <ListItemContent>
                                 {profile.replace("profile_", "")}


### PR DESCRIPTION
changed selectedProfile(s) to an array to handle profile selection
added toggleSelectedProfile()
removed handler open_all_profiles()
fix open all profiles on windows

### Tested and working on:
- [x] Windows
- [ ] Linux
- [ ] MacOS